### PR TITLE
chore: rename master branch references to main

### DIFF
--- a/tests/cli_commands/test_notebook.py
+++ b/tests/cli_commands/test_notebook.py
@@ -23,7 +23,7 @@ class TestNotebook:
         cfg["notebook"].update(
             **{
                 "repo_url": "https://example.com/repo-1234",
-                "repo_branch": "master",
+                "repo_branch": "main",
                 "repo_secret_arn": "arn:secret:1234",
             }
         )

--- a/tests/cli_commands/test_repo.py
+++ b/tests/cli_commands/test_repo.py
@@ -11,7 +11,7 @@ class TestRepo:
             "CodeRepositoryName": "my-models-repo-1234",
             "GitConfig": {
                 "RepositoryUrl": "https://example.com/repo-1234",
-                "Branch": "master",
+                "Branch": "main",
                 "SecretArn": "arn:secret:repo-1234",
             },
         }

--- a/tests/cli_commands/test_utils.py
+++ b/tests/cli_commands/test_utils.py
@@ -524,7 +524,7 @@ class TestCliUtils:
             "CodeRepositoryName": "modelling-project-repo-1",
             "GitConfig": {
                 "RepositoryUrl": "https://github.example.com/modelling-project",
-                "Branch": "master",
+                "Branch": "main",
                 "SecretArn": "arn:aws:secretsmanager:eu-west-1:111111111111:"
                 "secret:sagemaker-github-authentication-fLJGfa",
             },

--- a/tests/fixture_files/ml2p-multimodel.yml
+++ b/tests/fixture_files/ml2p-multimodel.yml
@@ -34,7 +34,7 @@ notebook:
   instance_type: "ml.t2.medium"
   volume_size: 8
   repo_url: "https://github.example.com/modelling-project"
-  repo_branch: "master"
+  repo_branch: "main"
   repo_secret_arn: "arn:aws:secretsmanager:eu-west-1:111111111111:secret:sagemaker-github-authentication-fLJGfa"
   security_group_ids:
     - "sg-1"

--- a/tests/fixture_files/ml2p-no-vpc.yml
+++ b/tests/fixture_files/ml2p-no-vpc.yml
@@ -13,5 +13,5 @@ notebook:
   instance_type: "ml.t2.medium"
   volume_size: 8
   repo_url: "https://github.example.com/modelling-project"
-  repo_branch: "master"
+  repo_branch: "main"
   repo_secret_arn: "arn:aws:secretsmanager:eu-west-1:111111111111:secret:sagemaker-github-authentication-fLJGfa"

--- a/tests/fixture_files/ml2p.yml
+++ b/tests/fixture_files/ml2p.yml
@@ -13,7 +13,7 @@ notebook:
   instance_type: "ml.t2.medium"
   volume_size: 8
   repo_url: "https://github.example.com/modelling-project"
-  repo_branch: "master"
+  repo_branch: "main"
   repo_secret_arn: "arn:aws:secretsmanager:eu-west-1:111111111111:secret:sagemaker-github-authentication-fLJGfa"
   security_group_ids:
     - "sg-1"


### PR DESCRIPTION
Updates references to the `master` branch name following the trunk branch rename to `main`.

Part of the team-wide master to main trunk branch rename initiative.
